### PR TITLE
[Fix] A second scan of a bar code will fail after refresh

### DIFF
--- a/src/BarcodeScannerForPhoneGap/widget/BarcodeScannerForPhoneGap.js
+++ b/src/BarcodeScannerForPhoneGap/widget/BarcodeScannerForPhoneGap.js
@@ -1,3 +1,4 @@
+/*global mxui, mx, dojo, cordova */
 (function(){
     'use strict';
 
@@ -32,7 +33,7 @@
 		update : function (obj, callback) {
 			if(typeof obj === 'string'){
 				mx.data.get({
-					guids    : [this._contextGuid],
+					guid    : obj,
 					callback : dojo.hitch(this, function(obj) {
 						this._loadData(obj);
 					})
@@ -60,7 +61,20 @@
 		},
 
 		_refresh : function(obj){
-			this._loadData(obj);
+            if(typeof obj === 'string'){
+				mx.data.get({
+					guid    : obj,
+					callback : dojo.hitch(this, function(obj) {
+						this._loadData(obj);            
+					})
+				});
+			} else if(obj === null){
+				// Sorry no data no show!
+				console.log('Whoops... the BarcodeScanner has no data!');
+			} else {
+				// Load data
+				this._loadData(obj);
+			}            
 		},
 
 		// Internal event setup.


### PR DESCRIPTION
Refresh of of the context object by i microflow, will result in the this._obj to be set with a guid string and not an object.
A second scan of a bar code will fail.
This fix will update the object correctly.

Widget should actual be fixed by using the proper widget (AMD) template using context property.
