### PR TITLE
Add Permission Usage Description iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The BarcodeScanner widget enables PhoneGap native barcode scanning functionality
 When Publishing this App for Mobile App Stores, add in the the Custom Phonegap/Cordova configuration the barcode plugin
 ``` xml
 <plugin name="phonegap-plugin-barcodescanner" />
+<edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
+    <string>To scan barcodes</string>
+</edit-config>
 ```
 
 ## Configuration


### PR DESCRIPTION
Barcode scanner widget works fine on Android but on iOS I get an Error message "Scanning failed: undefined"
iOS requires a permission description

Thanks to Wouter Scholten https://forum.mendixcloud.com/link/questions/90722