### PR TITLE
Fix plugin failure message 'undefined'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BarcodeScannerForPhoneGap",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BarcodeScannerForPhoneGap",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Creates a button to use the barcodescanner functionality",
   "license": "Apache-2.0",
   "author": "Mendix BV",

--- a/src/BarcodeScannerForPhoneGap/widget/BarcodeScannerForPhoneGap.js
+++ b/src/BarcodeScannerForPhoneGap/widget/BarcodeScannerForPhoneGap.js
@@ -60,7 +60,7 @@ define([
         },
 
         _barcodeFailure: function(error) {
-            mx.ui.error("Scanning failed: " + error.message);
+            mx.ui.error("Scanning failed: " + error);
         },
 
         _executeAction: function () {

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="BarcodeScanner For PhoneGap" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="BarcodeScanner For PhoneGap" version="3.2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BarcodeScannerForPhoneGap/BarcodeScannerForPhoneGap.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Instead of an object, the plugin returns a simple string on failure. This is documented here: https://github.com/phonegap/phonegap-plugin-barcodescanner#using-the-plugin